### PR TITLE
Add SSL automation for Hofladen

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,124 @@
 # KBI-Rechner
-KBI-Rechner Webversion
+
+Dieses Repository beinhaltet die vom ursprünglichen CustomTkinter-Programm extrahierte Logik. Die Berechnungen rund um Münzen, Scheine und Berichte sind nun unabhängig von einer GUI implementiert und können über eine Flask API angesprochen werden.
+
+## Projektstruktur
+
+```
+logic/
+    calculation.py  - Kernberechnungen (z.B. Gewichts‐zu‐Wert Umrechnung)
+    models.py       - Datenstrukturen für Münzen und Scheine
+    report.py       - Funktionen für Berichte und Wechselgeldberechnung
+app.py             - Einstiegspunkt der Flask API
+```
+
+## Nutzung
+
+Die Flask-Anwendung kann lokal gestartet werden:
+
+```bash
+python app.py
+```
+
+Danach ist die Weboberfläche unter `http://localhost:5000/` erreichbar.
+Die Seite nutzt Bootstrap 5 und kommuniziert per Fetch-API mit dem
+Endpunkt `/calculate`.
+
+Die weiteren Module können separat in eigenen Skripten importiert und verwendet werden.
+
+## API-Endpunkte
+
+### `POST /calculate`
+
+JSON-Eingabe::
+
+```json
+{
+  "coin_value": float,
+  "measured_weight": float,
+  "tare_weight": float
+}
+```
+
+Antwort::
+
+```json
+{
+  "calculated_value": float,
+  "coin_count": int
+}
+```
+
+## Weboberfläche
+
+Unter `http://localhost:5000/` wird ein kleines Formular bereitgestellt,
+mit dem sich der Münzwert bequem berechnen lässt. Die Seite ist
+responsiv aufgebaut und nutzt Bootstrap 5. Die Berechnung erfolgt per
+Fetch-Aufruf an den Endpunkt `/calculate`.
+
+## Deployment Guide
+
+Folgende Schritte richten den Dienst auf einem Ubuntu 22.04 Server ein.
+
+1. Kopiere das Repository auf den Server und wechsle in das Projektverzeichnis.
+2. Führe das bereitgestellte Skript `deploy.sh` aus:
+   ```bash
+   ./deploy.sh
+   ```
+   Das Skript erstellt eine Python-Umgebung, installiert die Abhängigkeiten
+   und legt die systemd‑Unit `kbi-rechner.service` an.
+3. Nach erfolgreicher Ausführung lauscht der Gunicorn‑Server auf Port 5000.
+4. Für den Reverse Proxy kann folgende Beispiel-Konfiguration in nginx
+   eingebunden werden:
+   ```nginx
+   include /path/to/project/nginx.conf;
+   ```
+
+Die Anwendung läuft im Produktionsmodus (`FLASK_ENV=production`). Änderungen
+an den Quellen benötigen einen Neustart des Dienstes:
+
+```bash
+sudo systemctl restart kbi-rechner.service
+```
+
+
+## Deployment für Märkischer Hofladen
+
+Die Anwendung kann unter dem Benutzer `hofladen` betrieben werden. Das Projekt liegt in
+`/home/hofladen/maerkischerhofladen/`.
+
+1. Wechsle in das Verzeichnis und führe das Skript `deploy-hofladen.sh` aus:
+   ```bash
+   ./deploy-hofladen.sh
+   ```
+   Das Skript erstellt eine virtuelle Umgebung, installiert die Abhängigkeiten
+   inklusive `gunicorn` und legt die systemd-Unit `maerkischerhofladen.service`
+   an.
+2. Nach dem Start lauscht Gunicorn auf Port `5001`.
+3. Für den Reverse Proxy kann folgende nginx-Konfiguration genutzt werden:
+   ```nginx
+   include /home/hofladen/maerkischerhofladen/maerkischerhofladen.conf;
+   ```
+
+Ein Neustart des Dienstes ist nach Änderungen an den Quellen nötig:
+```bash
+sudo systemctl restart maerkischerhofladen.service
+```
+
+## SSL Setup
+
+Um HTTPS für die Domain maerkischerhofladen.de zu aktivieren, kann das Skript
+`enable-ssl-hofladen.sh` genutzt werden. Es installiert bei Bedarf Certbot, legt
+ein Backup der vorhandenen nginx-Konfiguration an und richtet anschließend das
+Zertifikat sowie einen automatischen Redirect von HTTP auf HTTPS ein. Zusätzlich
+wird eine sichere Mozilla-Konfiguration eingebunden.
+
+Ausführen auf dem Server:
+
+```bash
+./enable-ssl-hofladen.sh
+```
+
+Das Skript erstellt auch eine Diffie-Hellman-Datei und legt
+`/etc/nginx/snippets/ssl-params.conf` mit den empfohlenen TLS-Optionen an.
+Nach erfolgreichem Zertifikatserwerb wird nginx neu geladen.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,43 @@
+"""Flask application exposing calculation endpoints."""
+
+from flask import Flask, jsonify, request, render_template
+from flask_cors import CORS
+
+from logic.calculation import coin_value_from_weight
+
+app = Flask(__name__)
+CORS(app)
+
+@app.get('/')
+def index():
+    """Render the minimal web frontend."""
+    return render_template('index.html')
+
+
+@app.post('/calculate')
+def calculate():
+    """Calculate coin value and count from weight measurement.
+
+    Expects JSON with ``coin_value``, ``measured_weight`` and ``tare_weight``.
+    Returns the calculated monetary value and number of coins detected.
+    """
+    data = request.get_json(force=True, silent=True) or {}
+    try:
+        coin_value = float(data['coin_value'])
+        measured_weight = float(data['measured_weight'])
+        tare_weight = float(data.get('tare_weight', 0))
+    except (KeyError, TypeError, ValueError):
+        return jsonify({"error": "Invalid input"}), 400
+
+    try:
+        value, count = coin_value_from_weight(
+            measured_weight, coin_value, extra_weight=tare_weight
+        )
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
+
+    return jsonify({"calculated_value": value, "coin_count": count})
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/deploy-hofladen.sh
+++ b/deploy-hofladen.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Deployment script for Maerkischer Hofladen Flask application
+
+set -e
+
+APP_DIR="$(dirname "$0")"
+VENV="$APP_DIR/venv"
+
+if [ ! -d "$VENV" ]; then
+    python3 -m venv "$VENV"
+fi
+
+source "$VENV/bin/activate"
+pip install --upgrade pip
+pip install -r "$APP_DIR/requirements.txt"
+pip install gunicorn
+
+echo "Creating systemd service file..."
+SERVICE_FILE="/etc/systemd/system/maerkischerhofladen.service"
+cat <<SERVICE > maerkischerhofladen.service
+[Unit]
+Description=Maerkischer Hofladen Flask App
+After=network.target
+
+[Service]
+User=hofladen
+WorkingDirectory=$APP_DIR
+Environment=FLASK_APP=app
+Environment=FLASK_ENV=production
+ExecStart=$APP_DIR/venv/bin/gunicorn --bind 0.0.0.0:5001 app:app
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+SERVICE
+
+sudo mv maerkischerhofladen.service "$SERVICE_FILE"
+
+sudo systemctl daemon-reload
+sudo systemctl enable maerkischerhofladen.service
+sudo systemctl restart maerkischerhofladen.service
+
+echo "Deployment completed."

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Deployment script for KBI-Rechner Flask application
+
+set -e
+
+APP_DIR="$(dirname "$0")"
+VENV="$APP_DIR/venv"
+
+if [ ! -d "$VENV" ]; then
+    python3 -m venv "$VENV"
+fi
+
+source "$VENV/bin/activate"
+pip install --upgrade pip
+pip install -r "$APP_DIR/requirements.txt"
+
+echo "Creating systemd service file..."
+SERVICE_FILE="/etc/systemd/system/kbi-rechner.service"
+cat <<SERVICE > kbi-rechner.service
+[Unit]
+Description=KBI Rechner Flask App
+After=network.target
+
+[Service]
+User=$(whoami)
+WorkingDirectory=$APP_DIR
+Environment=FLASK_APP=app
+Environment=FLASK_ENV=production
+ExecStart=$APP_DIR/venv/bin/gunicorn --bind 0.0.0.0:5000 app:app
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+SERVICE
+
+sudo mv kbi-rechner.service "$SERVICE_FILE"
+
+echo "Reloading systemd daemon and starting service..."
+sudo systemctl daemon-reload
+sudo systemctl enable kbi-rechner.service
+sudo systemctl restart kbi-rechner.service
+
+echo "Deployment completed."
+

--- a/enable-ssl-hofladen.sh
+++ b/enable-ssl-hofladen.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Enable SSL for Maerkischer Hofladen using certbot and nginx
+
+set -e
+
+DOMAIN_IDN="xn--mrkischerhofladen-qqb.de"
+EMAIL="admin@maerkischerhofladen.de"
+NGINX_CONF="/etc/nginx/sites-available/maerkischerhofladen.conf"
+SSL_SNIPPET="/etc/nginx/snippets/ssl-params.conf"
+
+# install certbot if not available
+if ! command -v certbot >/dev/null 2>&1; then
+    if command -v snap >/dev/null 2>&1; then
+        sudo snap install core
+        sudo snap refresh core
+        sudo snap install --classic certbot
+        sudo ln -sf /snap/bin/certbot /usr/bin/certbot
+    else
+        sudo apt update
+        sudo apt install -y certbot python3-certbot-nginx
+    fi
+fi
+
+# backup nginx config
+if [ -f "$NGINX_CONF" ]; then
+    sudo cp "$NGINX_CONF" "${NGINX_CONF}.bak.$(date +%F-%H%M)"
+fi
+
+# create recommended ssl params
+if [ ! -f "$SSL_SNIPPET" ]; then
+    sudo tee "$SSL_SNIPPET" > /dev/null <<'PARAMS'
+ssl_session_timeout 1d;
+ssl_session_cache shared:SSL:10m;
+ssl_session_tickets off;
+ssl_protocols TLSv1.2 TLSv1.3;
+ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256';
+ssl_prefer_server_ciphers off;
+ssl_ecdh_curve X25519:secp384r1;
+ssl_dhparam /etc/ssl/certs/dhparam.pem;
+PARAMS
+fi
+
+if [ ! -f /etc/ssl/certs/dhparam.pem ]; then
+    sudo openssl dhparam -out /etc/ssl/certs/dhparam.pem 2048
+fi
+
+# obtain certificate and configure nginx
+sudo certbot --nginx \
+    -d "$DOMAIN_IDN" \
+    -d "www.$DOMAIN_IDN" \
+    --non-interactive --agree-tos -m "$EMAIL" --redirect
+
+# ensure ssl params snippet included
+if ! grep -q "ssl-params.conf" "$NGINX_CONF"; then
+    sudo sed -i '/ssl_certificate_key/a \    include snippets/ssl-params.conf;' "$NGINX_CONF"
+fi
+
+sudo nginx -t
+sudo systemctl reload nginx
+

--- a/kbi-rechner.service
+++ b/kbi-rechner.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=KBI Rechner Flask App
+After=network.target
+
+[Service]
+User=www-data
+WorkingDirectory=/path/to/KBI-Rechner
+Environment=FLASK_APP=app
+Environment=FLASK_ENV=production
+ExecStart=/path/to/KBI-Rechner/venv/bin/gunicorn --bind 0.0.0.0:5000 app:app
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+

--- a/logic/calculation.py
+++ b/logic/calculation.py
@@ -1,0 +1,60 @@
+"""Core calculation logic for the cash register."""
+from typing import List, Tuple
+
+from .models import CashRegister, Currency
+
+# Weight of each coin in grams. Keys match the string representation of the value
+WEIGHT_PER_COIN = {
+    '2.00': 8.5,
+    '1.00': 7.5,
+    '0.50': 7.8,
+    '0.20': 5.74,
+    '0.10': 4.1,
+    '0.05': 3.92,
+    '0.02': 3.06,
+    '0.01': 2.3,
+}
+
+
+def coin_value_from_weight(weight: float, coin_value: float, extra_weight: float = 0) -> Tuple[float, int]:
+    """Return value and amount of coins based on a measured weight.
+
+    Parameters
+    ----------
+    weight: float
+        Measured weight in grams including possible extra weight.
+    coin_value: float
+        Monetary value of the analysed coin.
+    extra_weight: float, optional
+        Weight that should be subtracted from the measurement before
+        performing the calculation.
+    """
+    key = f"{coin_value:.2f}"
+    if key not in WEIGHT_PER_COIN:
+        raise ValueError(f"Unsupported coin value: {coin_value}")
+
+    mass = WEIGHT_PER_COIN[key]
+    count = int(round((weight - extra_weight) / mass))
+    total = round(count * coin_value, 2)
+    return total, count
+
+
+class CashCalculator:
+    """Utility to accumulate values and keep track of counts."""
+
+    def __init__(self, register: CashRegister):
+        self.register = register
+        self.values: List[float] = []
+        self.total: float = 0.0
+
+    def add_operand(self, amount: float, count: int, currency_value: float) -> float:
+        """Add a monetary amount to the calculation and update counts."""
+        self.total = round(self.total + amount, 2)
+        self.values.append(self.total)
+
+        # update available pieces
+        for currency in self.register.as_list():
+            if currency.value == currency_value:
+                currency.count += count
+                break
+        return self.total

--- a/logic/models.py
+++ b/logic/models.py
@@ -1,0 +1,26 @@
+from dataclasses import dataclass, field
+from typing import List
+
+@dataclass
+class Currency:
+    """Represents a single currency denomination (coin or bill)."""
+    value: float
+    count: int = 0
+
+    def total(self) -> float:
+        """Return the total monetary value of this currency."""
+        return round(self.value * self.count, 2)
+
+@dataclass
+class CashRegister:
+    """Container for all available coins and bills."""
+    coins: List[Currency] = field(default_factory=list)
+    bills: List[Currency] = field(default_factory=list)
+
+    def total(self) -> float:
+        """Calculate the overall monetary value of all currencies."""
+        return round(sum(c.total() for c in self.coins + self.bills), 2)
+
+    def as_list(self) -> List[Currency]:
+        """Return all currencies as a single list ordered bills then coins."""
+        return self.bills + self.coins

--- a/logic/report.py
+++ b/logic/report.py
@@ -1,0 +1,48 @@
+"""Reporting and withdrawal calculations."""
+from typing import List, Tuple
+
+from .models import CashRegister, Currency
+
+
+def get_withdrawable(currency_list: List[Tuple[float, int]], change: float) -> Tuple[float, List[Tuple[float, int]], List[Tuple[float, int]]]:
+    """Calculate withdrawable money and remaining change.
+
+    Parameters
+    ----------
+    currency_list: list of tuples ``(value, count)`` sorted by value descending.
+    change: amount of money that must remain in the register.
+    """
+    total = round(sum(value * count for value, count in currency_list), 2)
+    withdraw_value = round(total - change, 2)
+
+    withdraw_list: List[Tuple[float, int]] = []
+    change_list: List[Tuple[float, int]] = []
+
+    remaining = withdraw_value
+    for value, count in currency_list:
+        if value <= remaining:
+            max_q = int(remaining // value)
+            withdraw_count = min(max_q, count)
+            count -= withdraw_count
+        else:
+            withdraw_count = 0
+        remaining = round(remaining - withdraw_count * value, 2)
+        withdraw_list.append((value, withdraw_count))
+        change_list.append((value, count))
+
+    return withdraw_value, withdraw_list, change_list
+
+
+def calc_withdrawal(register: CashRegister, change: float) -> Tuple[float, List[Tuple[float, int]], List[Tuple[float, int]]]:
+    """Wrapper around :func:`get_withdrawable` using the registers current counts."""
+    currency_list = [(c.value, c.count) for c in register.as_list()]
+    # sort by value descending so larger denominations are preferred
+    currency_list.sort(key=lambda x: x[0], reverse=True)
+    return get_withdrawable(currency_list, change)
+
+
+def generate_report(register: CashRegister, change: float) -> Tuple[float, List[Tuple[float, int]], List[Tuple[float, int]]]:
+    """Return a tuple with total value, withdraw list and change list."""
+    total = register.total()
+    withdraw_value, withdraw_list, change_list = calc_withdrawal(register, change)
+    return total, withdraw_list, change_list

--- a/maerkischerhofladen.conf
+++ b/maerkischerhofladen.conf
@@ -1,0 +1,22 @@
+server {
+    listen 80;
+    server_name maerkischerhofladen.de www.maerkischerhofladen.de;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    server_name maerkischerhofladen.de www.maerkischerhofladen.de;
+
+    ssl_certificate /etc/letsencrypt/live/xn--mrkischerhofladen-qqb.de/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/xn--mrkischerhofladen-qqb.de/privkey.pem;
+    include snippets/ssl-params.conf;
+
+    location / {
+        proxy_pass http://127.0.0.1:5001;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/maerkischerhofladen.service
+++ b/maerkischerhofladen.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Maerkischer Hofladen Flask App
+After=network.target
+
+[Service]
+User=hofladen
+WorkingDirectory=/home/hofladen/maerkischerhofladen
+Environment=FLASK_APP=app
+Environment=FLASK_ENV=production
+ExecStart=/home/hofladen/maerkischerhofladen/venv/bin/gunicorn --bind 0.0.0.0:5001 app:app
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,13 @@
+server {
+    listen 80;
+    server_name example.com;
+
+    location / {
+        proxy_pass http://127.0.0.1:5000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+flask-cors
+gunicorn

--- a/ssl-params.conf
+++ b/ssl-params.conf
@@ -1,0 +1,9 @@
+ssl_session_timeout 1d;
+ssl_session_cache shared:SSL:10m;
+ssl_session_tickets off;
+ssl_protocols TLSv1.2 TLSv1.3;
+ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256';
+ssl_prefer_server_ciphers off;
+ssl_ecdh_curve X25519:secp384r1;
+ssl_dhparam /etc/ssl/certs/dhparam.pem;
+

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,0 +1,2 @@
+body { background-color: #f8f9fa; }
+#result { font-weight: bold; }

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1,0 +1,26 @@
+document.getElementById('calcForm').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const data = {
+        coin_value: parseFloat(document.getElementById('coinValue').value),
+        measured_weight: parseFloat(document.getElementById('measuredWeight').value),
+        tare_weight: parseFloat(document.getElementById('tareWeight').value)
+    };
+
+    try {
+        const response = await fetch('/calculate', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify(data)
+        });
+        const result = await response.json();
+        if (!response.ok) {
+            throw new Error(result.error || 'Request failed');
+        }
+        document.getElementById('valueOutput').textContent = result.calculated_value.toFixed(2);
+        document.getElementById('countOutput').textContent = result.coin_count;
+    } catch (err) {
+        document.getElementById('valueOutput').textContent = '-';
+        document.getElementById('countOutput').textContent = '-';
+        alert(err.message);
+    }
+});

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>KBI-Rechner</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="{{ url_for('static', filename='css/style.css') }}" rel="stylesheet">
+</head>
+<body>
+<div class="container py-4">
+    <h1 class="mb-4">KBI-Rechner</h1>
+    <form id="calcForm" class="row g-3">
+        <div class="col-12 col-md-4">
+            <label for="coinValue" class="form-label">Coin Value</label>
+            <select id="coinValue" class="form-select" required>
+                <option value="2.00">2.00 €</option>
+                <option value="1.00">1.00 €</option>
+                <option value="0.50">0.50 €</option>
+                <option value="0.20">0.20 €</option>
+                <option value="0.10">0.10 €</option>
+                <option value="0.05">0.05 €</option>
+                <option value="0.02">0.02 €</option>
+                <option value="0.01">0.01 €</option>
+            </select>
+        </div>
+        <div class="col-12 col-md-4">
+            <label for="measuredWeight" class="form-label">Measured Weight (g)</label>
+            <input type="number" step="any" id="measuredWeight" class="form-control" required>
+        </div>
+        <div class="col-12 col-md-4">
+            <label for="tareWeight" class="form-label">Tare Weight (g)</label>
+            <input type="number" step="any" id="tareWeight" class="form-control" value="34">
+        </div>
+        <div class="col-12">
+            <button type="submit" class="btn btn-primary">Calculate</button>
+        </div>
+    </form>
+
+    <div id="result" class="mt-4">
+        <p>Total Value (€): <span id="valueOutput">-</span></p>
+        <p>Coin Count: <span id="countOutput">-</span></p>
+    </div>
+</div>
+
+<script src="{{ url_for('static', filename='js/app.js') }}"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `enable-ssl-hofladen.sh` for Let's Encrypt setup on the Hofladen domain
- extend nginx config with SSL server blocks and recommended params
- include Mozilla SSL parameters in `ssl-params.conf`
- document HTTPS setup steps in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684569011a78833098233b71a886f7ac